### PR TITLE
Make 'mvn install' work again

### DIFF
--- a/archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/src/main/resources/archetype-resources/pom.xml
@@ -109,7 +109,7 @@
                         <descriptorRef>jar-with-dependencies</descriptorRef>
                     </descriptorRefs>
                     <appendAssemblyId>false</appendAssemblyId>
-                    <attach>false</attach>
+                    <attach>true</attach>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
When using the current version of the WPS archetype, one could easily make use of `mvn package` (which creates the JAR file in the target subfolder).

But `mvn install` (i.e. the installation of the JAR in the local M2 repository) does not work as the built JAR file was not treated as the final artifact.

This PR makes `mvn install` work again (for WPS projects based on this archetype) by setting the `attach` property of the `maven-assembly-plugin` to `true`.

Related doc: https://maven.apache.org/plugins/maven-assembly-plugin/single-mojo.html#attach